### PR TITLE
Bugfix - vendor publishing

### DIFF
--- a/src/Exceptions/InvalidConfigurationException.php
+++ b/src/Exceptions/InvalidConfigurationException.php
@@ -10,6 +10,6 @@ class InvalidConfigurationException extends Exception
     {
         $typeExpected = collect($typeExpected)->implode(',');
 
-        return parent::__construct("Invalid configuration provided for {$key}. `{$typeProvided}` provided, but `{$typeExpected}` expected");
+        parent::__construct("Invalid configuration provided for {$key}. `{$typeProvided}` provided, but `{$typeExpected}` expected");
     }
 }

--- a/src/Exceptions/InvalidEntityModelException.php
+++ b/src/Exceptions/InvalidEntityModelException.php
@@ -10,6 +10,6 @@ class InvalidEntityModelException extends Exception
     {
         $typeExpected = collect($typeExpected)->implode(',');
 
-        return parent::__construct("Invalid entity model provided. `{$typeProvided}` provided, but any of `{$typeExpected}` expected");
+        parent::__construct("Invalid entity model provided. `{$typeProvided}` provided, but any of `{$typeExpected}` expected");
     }
 }

--- a/src/Services/VocabService.php
+++ b/src/Services/VocabService.php
@@ -56,9 +56,9 @@ class VocabService implements VocabInterface
                 'entity_id' => $entity->id,
                 'custom_name' => $as
             ];
-
-            return $vocab->vocabMapper()->updateOrCreate($data, $data);
         }
+
+        return $vocab->vocabMapper()->updateOrCreate($data, $data);
     }
 
     public function getVocabFor(object $entity, string $handler): ?VocabMapper

--- a/src/Traits/VocabHelper.php
+++ b/src/Traits/VocabHelper.php
@@ -6,13 +6,13 @@ trait VocabHelper
 {
     public function getMigrationDirectory(): string
     {
-        $main = database_path('/database/migrations/');
+        $main = database_path('/migrations');
         $subDir = config('vocab.migration_sub_dir', '');
 
         if (!empty($subDir)) {
             $subDir = ltrim(rtrim($subDir, "/"), "/");
         }
 
-        return sprintf('%s%s', $main, $subDir);
+        return sprintf('%s/%s', $main, $subDir);
     }
 }

--- a/tests/Unit/VocabHelperTest.php
+++ b/tests/Unit/VocabHelperTest.php
@@ -16,7 +16,7 @@ final class VocabHelperTest extends TestCase
             use VocabHelper;
         };
 
-        $this->assertEquals(database_path('/database/migrations/'), $model->getMigrationDirectory());
+        $this->assertEquals(database_path('/migrations/'), $model->getMigrationDirectory());
     }
 
     public function testMigrationSubPathUsingCustomPath()
@@ -30,6 +30,6 @@ final class VocabHelperTest extends TestCase
             use VocabHelper;
         };
 
-        $this->assertEquals(database_path('/database/migrations/' . $subDir), $model->getMigrationDirectory());
+        $this->assertEquals(database_path('/migrations/' . $subDir), $model->getMigrationDirectory());
     }
 }


### PR DESCRIPTION
Bug fixe and minor adjustments:

- Running `php artisan vendor:publish --tag=vocab-mapper-migration` was publishing into a wrong sub-directory, /database/migrations/database/migrations/. This should now be fixed. 
-  Remove the return statement in the constructors of the exception handlers
- Update and set the correct return type for mapVocabTo